### PR TITLE
Fix linker error

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '11.0'
+platform :ios, '11.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -41,5 +41,8 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+        config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'arm64'
+    end
   end
 end


### PR DESCRIPTION
Ticket: #24 
It fixes the iOS build issues.

`Error (Xcode): Building for iOS Simulator, but linking in object file built for iOS, file '/Users/vinothvino/Documents/EnsembleUI/starter/ios/Pods/GoogleMaps/Maps/Frameworks/GoogleMaps.framework/GoogleMaps' for architecture arm64`